### PR TITLE
Ensure that child processes are forked, not spawned.

### DIFF
--- a/bin/ddsmt
+++ b/bin/ddsmt
@@ -19,12 +19,18 @@
 # You should have received a copy of the GNU General Public License
 # along with ddSMT.  If not, see <https://www.gnu.org/licenses/>.
 
+import multiprocessing
 import os
 import sys
 
-__root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
-sys.path.insert(0, __root_dir)
+if __name__ == '__main__':
+    # Ensure that child processes are forked. Some platforms, e.g., macOS,
+    # default to spawning child processes, which does not preserve the value of
+    # global variables.
+    multiprocessing.set_start_method('fork')
 
-from ddsmt import __main__  # noqa: E402
+    __root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+    sys.path.insert(0, __root_dir)
 
-__main__.main()
+    from ddsmt import __main__  # noqa: E402
+    __main__.main()


### PR DESCRIPTION
On macOS (I tested 11.3.1 with Python version 3.9.5), child processes seem to
be spawned instead of forked by default:

```
>>> import multiprocessing
>>> multiprocessing.get_context()
<multiprocessing.context.SpawnContext object at 0x104092280>
```

This causes issues with global variables such as `__TMPDIR` in tmpfiles.py,
which is `None` for children when the process is spawned instead of forked.
This commit fixes the issue by setting the multiprocessing context explicitly.
The commit also moves the manipulation of `sys.path` and the import of the
`ddsmt` module after changing the context. Otherwise, the context is already
implicitly set when we get to `if __name__ == '__main__'`.