### PR TITLE
Mutator to erase entries from "declare-datatypes" and "define-funs-rec"

### DIFF
--- a/ddsmt/mutators_smtlib.py
+++ b/ddsmt/mutators_smtlib.py
@@ -173,6 +173,30 @@ class RemoveAnnotation:
         return 'remove annotation'
 
 
+class RemoveRecursiveDefinition:
+    """Remove a datatype or function definition from a node that defines
+    mutually-recursive datatypes or functions."""
+    def filter(self, node):
+        return node.has_ident() and node.get_ident() in [
+            'declare-datatypes', 'define-funs-rec'
+        ]
+
+    def mutations(self, node):
+        head = node[0]
+        declarations = node[1]
+        definitions = node[2]
+        if len(declarations) != len(definitions):
+            return
+        for i in range(len(declarations)):
+            all_other_decls = declarations[:i] + declarations[i + 1:]
+            all_other_defns = definitions[:i] + definitions[i + 1:]
+            new = Node(head, all_other_decls, all_other_defns)
+            yield Simplification({node.id: new}, [])
+
+    def __str__(self):
+        return 'remove recursive definition'
+
+
 class SimplifyLogic:
     """Replace the logic specified in ``(check-logic ...)`` with a simpler one.
     """
@@ -293,6 +317,7 @@ def get_mutators():
         'LetElimination': 'let-elimination',
         'LetSubstitution': 'let-substitution',
         'RemoveAnnotation': 'remove-annotation',
+        'RemoveRecursiveDefinition': 'remove-recursive-definition',
         'SimplifyLogic': 'simplify-logic',
         'SimplifyQuotedSymbols': 'simplify-quoted-symbols',
         'SimplifySymbolNames': 'simplify-symbol-names',


### PR DESCRIPTION
Hi, I have written this some time ago to reduce some of my formulas that use those recursive definitions.
I'm not sure if it fits in well with the rest of the mutators.

---

This allows to reduce a file like

	(define-funs-rec ((a () Bool) (b () Bool) (c () Bool)) (true false (or a b)))
	(assert (= a b))
	(check-sat)

where "c" is not relevant. The generic "erase" mutator doesn't work
because we also need to remove the definition of "c" - in this example
"(or a b)".