### PR TITLE
Implementing initial detection of datatypes

### DIFF
--- a/ddsmt/mutators_datatypes.py
+++ b/ddsmt/mutators_datatypes.py
@@ -92,3 +92,9 @@ def get_mutators():
         'RemoveDatatype': 'dt-rm-datatype',
         'RemoveDatatypeIdentity': 'dt-rm-identity',
     }
+
+def is_relevant(node):
+    """Checks whether this theory might be relevant for this node."""
+    if node.has_ident():
+        return node.get_ident() in ['declare-datatypes', 'declare-datatype']
+    return False

--- a/ddsmt/tests/test_mutators_datatypes.py
+++ b/ddsmt/tests/test_mutators_datatypes.py
@@ -11,6 +11,17 @@ def test_datatypes_get_mutators():
     assert len(d) == 3
 
 
+def test_strings_is_relevant():
+    color_dt = (Node('Color 0'), Node('red', 'green', 'blue'))
+    assert mutators_datatypes.is_relevant(Node('declare-datatypes', color_dt))
+    assert mutators_datatypes.is_relevant(Node('declare-datatype', color_dt))
+    assert not mutators_datatypes.is_relevant(Node('declare-const', 'x', 'Real'))
+    assert not mutators_datatypes.is_relevant(
+        Node('declare-fun', 'x', (), 'Real'))
+    assert not mutators_datatypes.is_relevant(Node())
+    assert not mutators_datatypes.is_relevant(Node('assert', 'x'))
+
+
 def test_datatypes_remove_constructor():
     m = mutators_datatypes.RemoveConstructor()
     assert isinstance(str(m), str)


### PR DESCRIPTION
This PR implements very rudimentary support for `is_relevant` for the datatypes logic. This avoids *enabling* the datatype mutators on SMTLIB instances that do not use datatypes (e.g., pure QF_BV instances).

After reading SMTLIB 2.6 (2021-05-12), it doesn't appear that you can declare a datatype const/function without having the datatype sort "forward declared" (i.e., there are no built-in datatype sorts). This makes the relevancy check very easy, as you can "just" check for the use of `declare-datatype` and `declare-datatypes` (and you don't need to "look inside" const/function declarations).

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>