### PR TITLE
fix: change priority constructors

### DIFF
--- a/ddsmt/smtlib.py
+++ b/ddsmt/smtlib.py
@@ -414,6 +414,11 @@ def _get_sort_aux(node):  # noqa: C901
         if is_operator_app(node, 'ite') and len(node) > 2:
             return get_sort(node[2])
         ident = node.get_ident()
+        # user-declared datatype constructors may legally shadow
+        # built-in operator names (e.g. a constructor named `fp`);
+        # resolve them first.
+        if ident in __datatypes_constructors:
+            return __datatypes_constructors[ident]
         # operators that return Bool
         if ident in [
                 # core theory
@@ -520,8 +525,6 @@ def _get_sort_aux(node):  # noqa: C901
             return None
         if ident == 'store':
             return get_sort(node[1])
-        if ident in __datatypes_constructors:
-            return __datatypes_constructors[ident]
 
     # indexed operators
     if is_indexed_operator_app(node, 'divisible'):


### PR DESCRIPTION
User-defined constructors should have higher priority compared with builtin ones.

```
(declare-datatypes ((M 0)) (((fp (g (_ FloatingPoint 11 53))))))
(declare-const x M)
(assert (let ((y (fp ((_ to_fp 11 53) #x0000000000000000)))) (= x y)))
(check-sat)
```

Without this commit smt chunk above triggers python exception: `./bin/ddsmt repro.smt out.smt2 /bin/true`

```
  File "ddsmt/smtlib.py", line 549, in get_sort
    sort = _get_sort_aux(node)
           ^^^^^^^^^^^^^^^^^^^
  File "ddsmt/smtlib.py", line 513, in _get_sort_aux
    ew = get_bv_width(node[2])
                      ~~~~^^^
  File "ddsmt/nodes.py", line 104, in __getitem__
    return self.data[key]
           ~~~~~~~~~^^^^^
IndexError: tuple index out of range
```